### PR TITLE
Replace hardcoded URL in activation email with a reversed URL.

### DIFF
--- a/registration_defaults/templates/registration/activation_email.txt
+++ b/registration_defaults/templates/registration/activation_email.txt
@@ -5,7 +5,7 @@ and your address will be removed from our records.
 To activate this account, please click the following link within the next 
 {{ expiration_days }} days:
 
-http://{{site.domain}}/accounts/activate/{{ activation_key }}
+http://{{site.domain}}{% url registration_activate activation_key %}
 
 Sincerely,
 {{ site.name }} Management


### PR DESCRIPTION
The current version of activation_email.txt uses a hardcoded URL for the activation link. This is broken on sites that use a different URL prefix for the registration app (i.e., one other than "accounts"). My patch fixes the problem by using the {% url %} template tag.
